### PR TITLE
Use method names similar to the ones used in the Sprint template classes

### DIFF
--- a/spring-concurrency-control/src/main/java/org/springframework/roo/petclinic/web/ConcurrencyCallback.java
+++ b/spring-concurrency-control/src/main/java/org/springframework/roo/petclinic/web/ConcurrencyCallback.java
@@ -14,5 +14,5 @@ public interface ConcurrencyCallback<T> {
      *
      * @return a result object, or {@code null}
      */
-    T executeWithOcc();
+    T doInConcurrency();
 }

--- a/spring-concurrency-control/src/main/java/org/springframework/roo/petclinic/web/ConcurrencyTemplate.java
+++ b/spring-concurrency-control/src/main/java/org/springframework/roo/petclinic/web/ConcurrencyTemplate.java
@@ -12,7 +12,7 @@ import org.springframework.ui.Model;
  * concurrency exception handling.
  *
  * @param <T> Generic type that indicates the type of element that should be returned after
- *            {@link #executeWithOcc(ConcurrencyCallback)} is called.
+ *            {@link #execute(ConcurrencyCallback)} is called.
  */
 public class ConcurrencyTemplate<T> {
 
@@ -59,10 +59,10 @@ public class ConcurrencyTemplate<T> {
      * @param action The action that should be executed and that could produce a Concurrency Exception.
      * @return An object with the same type as the specified in the ConcurrencyTemplate constructor
      */
-    public T executeWithOcc(ConcurrencyCallback<T> action) {
+    public T execute(ConcurrencyCallback<T> action) {
         try {
             // Execute the provided action and return the result
-            return action.executeWithOcc();
+            return action.doInConcurrency();
         } catch (ObjectOptimisticLockingFailureException ex) {
             // If some Concurrency Exception appears, log the error as debug level
             // and throws a custom exception that contains all the information about

--- a/spring-concurrency-control/src/main/java/org/springframework/roo/petclinic/web/OwnersItemThymeleafController.java
+++ b/spring-concurrency-control/src/main/java/org/springframework/roo/petclinic/web/OwnersItemThymeleafController.java
@@ -49,7 +49,7 @@ public class OwnersItemThymeleafController implements ConcurrencyManager<Owner> 
         // Create Concurrency Spring Template to ensure that the following code will manage the
         // possible concurrency exceptions that appears and execute the provided coded inside the Spring template.
         // If some concurrency exception appears the template will manage it.
-        Owner savedOwner = new ConcurrencyTemplate<Owner>(this, owner, model).executeWithOcc(() -> {
+        Owner savedOwner = new ConcurrencyTemplate<Owner>(this, owner, model).execute(() -> {
             return getOwnerService().save(owner);
         });
 

--- a/spring-concurrency-control/src/main/java/org/springframework/roo/petclinic/web/PetsItemThymeleafController.java
+++ b/spring-concurrency-control/src/main/java/org/springframework/roo/petclinic/web/PetsItemThymeleafController.java
@@ -45,7 +45,7 @@ public class PetsItemThymeleafController implements ConcurrencyManager<Pet> {
         // Create Concurrency Spring Template to ensure that the following code will manage the
         // possible concurrency exceptions that appears and execute the provided coded inside the Spring template.
         // If some concurrency exception appears the template will manage it.
-        Pet savedPet = new ConcurrencyTemplate<Pet>(this, pet, model).executeWithOcc(() -> {
+        Pet savedPet = new ConcurrencyTemplate<Pet>(this, pet, model).execute(() -> {
             return getPetService().save(pet);
         });
 


### PR DESCRIPTION
The Spring template classes usually have an _execute_ method, and use a Callback interface with a _doInXXX_ method. I think it's better to follow the same naming scheme.